### PR TITLE
docs: enforce spell and link validation

### DIFF
--- a/.docs-templates/architecture-template.md
+++ b/.docs-templates/architecture-template.md
@@ -1,0 +1,41 @@
+---
+purpose: "Explain system architecture, context, and design decisions."
+audience: "Engineers, architects, stakeholders"
+owner: "<team or individual>"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Draft"
+---
+
+# {{System}} Architecture & Context
+
+## When to Use This
+
+- Onboard new engineers to the system fundamentals.
+- Explain constraints and trade-offs to reviewers.
+
+## Problem Statement
+
+- What prompted the system and which pain points it solves.
+
+## Solution Overview
+
+- Core capabilities and modules.
+
+## Architecture Diagram
+
+```text
+{{ASCII or link to diagram}}
+```
+
+## Key Decisions
+
+- Decision, rationale, date, linked ADR or issue.
+
+## Operational Considerations
+
+- Scaling, observability, deployment workflow.
+
+## Related Docs
+
+- `docs/index.md`
+- `{{link to workflow or policy doc}}`

--- a/.docs-templates/cli-reference-template.md
+++ b/.docs-templates/cli-reference-template.md
@@ -1,0 +1,57 @@
+---
+purpose: "Document CLI surface area, arguments, and examples."
+audience: "CLI users, automation engineers"
+owner: "<team or individual>"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Draft"
+---
+
+# {{Project}} CLI Reference
+
+## When to Use This
+
+- Running commands from terminals, scripts, or CI pipelines.
+- Validating CLI changes during reviews.
+
+## Prerequisites
+
+- Install {{Project}} via `uv pip install ...`.
+- `just setup` completed locally.
+
+## Commands
+
+### {{Command}}
+
+Purpose: what the command does.
+
+```bash
+{{binary}} {{command}} --flag value
+```
+
+Options:
+
+- `--flag` — description (default: value)
+
+### {{Next Command}}
+
+Purpose: what the command does.
+
+```bash
+{{binary}} {{next}}
+```
+
+## Configuration
+
+```yaml
+key: value
+```
+
+## Verification
+
+- Sample output or log snippet.
+- Tests to run when flags change.
+
+## Related Docs
+
+- `README.md`
+- `docs/index.md`

--- a/.docs-templates/contributor-guide-template.md
+++ b/.docs-templates/contributor-guide-template.md
@@ -1,0 +1,50 @@
+---
+purpose: "Describe contributor expectations, workflows, and guardrails."
+audience: "Contributors, reviewers, release managers"
+owner: "<team or individual>"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Draft"
+---
+
+# {{Repository}} Contributor Guide
+
+## When to Use This
+
+- Review before opening PRs or shipping releases.
+- Reference during code review for workflow questions.
+
+## Core Principles
+
+1. **{{Rule name}}** — why the rule exists.
+2. **{{Rule name}}** — what to do instead of the anti-pattern.
+
+## Prerequisites
+
+- Access to required secrets or org membership.
+- Local environment configured with `just setup`.
+
+## Development Workflow
+
+1. Create branch with `gt create --all -m "feat: summary"`.
+2. Write tests before implementation.
+3. Run `just ci` prior to committing.
+4. Submit PR with checklist filled.
+
+## Tooling Commands
+
+```bash
+just setup
+just lint check
+just test all
+just docs check
+```
+
+## Verification & Sign-off
+
+- Capture test output for major changes.
+- Update documentation when behavior changes.
+
+## Related Docs
+
+- `CLAUDE.md`
+- `docs/index.md`

--- a/.docs-templates/how-to-template.md
+++ b/.docs-templates/how-to-template.md
@@ -1,0 +1,39 @@
+---
+purpose: "Provide a repeatable procedure for a specific task."
+audience: "Operators, maintainers"
+owner: "<team or individual>"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Draft"
+---
+
+# {{Task}} Guide
+
+## When to Use This
+
+- Trigger scenario A.
+- Trigger scenario B.
+
+## Prerequisites
+
+- Accounts, secrets, tooling required.
+- Links to setup references.
+
+## Steps
+
+1. Description of step one.
+
+   ```bash
+   command --flag
+   ```
+
+2. Description of step two.
+
+## Verification
+
+- Expected output or screenshot.
+- Rollback / failure recovery instructions.
+
+## References
+
+- `{{related policy}}`
+- `docs/index.md`

--- a/.docs-templates/overview-template.md
+++ b/.docs-templates/overview-template.md
@@ -1,0 +1,48 @@
+---
+purpose:
+  "Document the product overview, install paths, and quick start examples."
+audience: "New users, maintainers, stakeholders"
+owner: "<team or individual>"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Draft"
+---
+
+# {{Project}} Overview
+
+## When to Use This
+
+- Read when evaluating {{Project}} or starting integration.
+- Share with partners who need a concise capability tour.
+
+## Prerequisites
+
+- {{Required tooling or access}}
+- {{Link to setup instructions}}
+
+## Installation
+
+```bash
+just setup
+uv pip install "{{package}} @ git+https://github.com/{{org}}/{{repo}}@{{tag}}"
+```
+
+## Quick Start
+
+```python
+from {{module}} import {{api}}
+```
+
+## Optional Features
+
+- **Feature name** — how to enable it.
+- **Telemetry/metrics** — environment variables to export.
+
+## Verification
+
+- Run `just test` and confirm the example succeeds.
+- Capture outputs or screenshots in release notes if behavior changes.
+
+## Related Docs
+
+- `docs/index.md`
+- `{{link to CLI reference}}`

--- a/.docs-templates/policy-template.md
+++ b/.docs-templates/policy-template.md
@@ -1,0 +1,39 @@
+---
+purpose: "Document mandatory rules and escalation paths."
+audience: "Contributors, reviewers, operators"
+owner: "<team or individual>"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Draft"
+---
+
+# {{Policy Title}}
+
+## When to Use This
+
+- Anytime the covered workflow triggers.
+- Before approving or merging related changes.
+
+## Prerequisites
+
+- Required tooling or permissions.
+
+## Rules
+
+1. **ALWAYS** required action and rationale.
+2. **NEVER** forbidden action and rationale.
+
+## Procedure
+
+```bash
+command sequence
+```
+
+## Verification
+
+- How to confirm compliance.
+- Escalation path when conflicts appear.
+
+## Related Docs
+
+- `docs/index.md`
+- `{{associated how-to}}`

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -142,11 +142,24 @@ jobs:
       - name: Determine models (per category)
         id: models
         run: |
-          # Allow repo vars to override defaults
-          docs_model="${{ vars.CLAUDE_MODEL_DOCS || steps.models_defaults.outputs.SONNET4 }}"
-          just_model="${{ vars.CLAUDE_MODEL_JUSTFILE || steps.models_defaults.outputs.SONNET4 }}"
-          corr_model="${{ vars.CLAUDE_MODEL_CORRECTNESS || steps.models_defaults.outputs.OPUS4 }}"
-          over_model="${{ vars.CLAUDE_MODEL_OVERENGINEERING || steps.models_defaults.outputs.SONNET4 }}"
+          sanitize() {
+            local candidate="$1"
+            local default="$2"
+            if [[ -z "$candidate" ]]; then
+              echo "$default"
+              return
+            fi
+            if echo "$candidate" | grep -Eq '^claude-.*-(opus|sonnet)-4'; then
+              echo "$candidate"
+            else
+              echo "$default"
+            fi
+          }
+
+          docs_model=$(sanitize "${{ vars.CLAUDE_MODEL_DOCS }}" "${{ steps.models_defaults.outputs.SONNET4 }}")
+          just_model=$(sanitize "${{ vars.CLAUDE_MODEL_JUSTFILE }}" "${{ steps.models_defaults.outputs.SONNET4 }}")
+          corr_model=$(sanitize "${{ vars.CLAUDE_MODEL_CORRECTNESS }}" "${{ steps.models_defaults.outputs.OPUS4 }}")
+          over_model=$(sanitize "${{ vars.CLAUDE_MODEL_OVERENGINEERING }}" "${{ steps.models_defaults.outputs.SONNET4 }}")
 
           echo "docs_model=$docs_model" >> $GITHUB_OUTPUT
           echo "just_model=$just_model" >> $GITHUB_OUTPUT

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -143,9 +143,9 @@ jobs:
         id: models
         run: |
           # Allow repo vars to override defaults
-          docs_model="${{ vars.CLAUDE_MODEL_DOCS || steps.models_defaults.outputs.HAIKU35 }}"
-          just_model="${{ vars.CLAUDE_MODEL_JUSTFILE || steps.models_defaults.outputs.HAIKU35 }}"
-          corr_model="${{ vars.CLAUDE_MODEL_CORRECTNESS || steps.models_defaults.outputs.SONNET4 }}"
+          docs_model="${{ vars.CLAUDE_MODEL_DOCS || steps.models_defaults.outputs.SONNET4 }}"
+          just_model="${{ vars.CLAUDE_MODEL_JUSTFILE || steps.models_defaults.outputs.SONNET4 }}"
+          corr_model="${{ vars.CLAUDE_MODEL_CORRECTNESS || steps.models_defaults.outputs.OPUS4 }}"
           over_model="${{ vars.CLAUDE_MODEL_OVERENGINEERING || steps.models_defaults.outputs.SONNET4 }}"
 
           echo "docs_model=$docs_model" >> $GITHUB_OUTPUT

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -144,15 +144,17 @@ jobs:
         run: |
           sanitize() {
             local candidate="$1"
-            local default="$2"
+            local fallback="$2"
             if [[ -z "$candidate" ]]; then
-              echo "$default"
+              echo "$fallback"
               return
             fi
-            if echo "$candidate" | grep -Eq '^claude-.*-(opus|sonnet)-4'; then
+            if [[ "$candidate" == claude-* ]] && [[ "$candidate" == *-4* ]] && {
+                 [[ "$candidate" == *sonnet* ]] || [[ "$candidate" == *opus* ]];
+               }; then
               echo "$candidate"
             else
-              echo "$default"
+              echo "$fallback"
             fi
           }
 
@@ -160,11 +162,15 @@ jobs:
           just_model=$(sanitize "${{ vars.CLAUDE_MODEL_JUSTFILE }}" "${{ steps.models_defaults.outputs.SONNET4 }}")
           corr_model=$(sanitize "${{ vars.CLAUDE_MODEL_CORRECTNESS }}" "${{ steps.models_defaults.outputs.OPUS4 }}")
           over_model=$(sanitize "${{ vars.CLAUDE_MODEL_OVERENGINEERING }}" "${{ steps.models_defaults.outputs.SONNET4 }}")
+          sonnet_family=$(sanitize "${{ vars.CLAUDE_MODEL_SONNET }}" "$docs_model")
+          opus_family=$(sanitize "${{ vars.CLAUDE_MODEL_OPUS }}" "${{ steps.models_defaults.outputs.OPUS4 }}")
 
           echo "docs_model=$docs_model" >> $GITHUB_OUTPUT
           echo "just_model=$just_model" >> $GITHUB_OUTPUT
           echo "corr_model=$corr_model" >> $GITHUB_OUTPUT
           echo "over_model=$over_model" >> $GITHUB_OUTPUT
+          echo "family_sonnet=$sonnet_family" >> $GITHUB_OUTPUT
+          echo "family_opus=$opus_family" >> $GITHUB_OUTPUT
 
       - name: Build combined prompt
         id: combined_prompt
@@ -277,10 +283,10 @@ jobs:
           # If a model family was explicitly requested, honor it.
           case "${FAMILY}" in
             opus)
-              model="${{ vars.CLAUDE_MODEL_OPUS || steps.models_defaults.outputs.OPUS4 }}";
+              model="${{ steps.models.outputs.family_opus }}";
               ;;
             sonnet)
-              model="${{ vars.CLAUDE_MODEL_SONNET || steps.models.outputs.corr_model }}";;
+              model="${{ steps.models.outputs.family_sonnet }}";;
             haiku)
               model="${{ steps.models.outputs.docs_model }}";;
             *)
@@ -300,10 +306,10 @@ jobs:
           model='${{ steps.select_model.outputs.model }}'
           cats='${{ steps.determine.outputs.cats_csv }}'
           if echo "$cats" | grep -Eq 'correctness|overengineering'; then
-            if [ -z "$model" ] || ! echo "$model" | grep -Eq '^claude-.*-4(\.|-|$)'; then
-              echo "Analysis categories require Claude 4.x (selected='$model')." >&2
-              echo "Set CLAUDE_MODEL_SONNET/OPUS to a 4.x model or enable 4.x access for this key." >&2
-              exit 1
+            if [[ -z "$model" ]] || ! { [[ "$model" == claude-* ]] && [[ "$model" == *-4* ]] && { [[ "$model" == *sonnet* ]] || [[ "$model" == *opus* ]]; }; }; then
+                echo "Analysis categories require Claude 4.x (selected='$model')." >&2
+                echo "Set CLAUDE_MODEL_SONNET/OPUS to a 4.x model or enable 4.x access for this key." >&2
+                exit 1
             fi
           fi
 

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,0 +1,31 @@
+name: docs-quality
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "CLAUDE.md"
+      - "CONTEXT.md"
+      - ".docs-templates/**"
+      - ".github/workflows/docs-quality.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        run: sudo apt-get update && sudo apt-get install -y just
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install lychee
+        run: cargo install lychee --version 0.13.0
+      - uses: astral-sh/setup-uv@v3
+      - name: Run docs checks (markdownlint + cspell + lychee)
+        run: just docs check

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ Thumbs.db
 
 # Documentation build
 docs/_build/
+docs/_build/.lycheecache
+.lycheecache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,13 @@
+---
+purpose:
+  "Set contributor expectations, tooling rules, and workflow guardrails for
+  llm-cli-tools-core."
+audience: "Contributors, reviewers, automation agents"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # llm-cli-tools-core - Claude Development Guide
 
 ## 🎯 CORE PRINCIPLES
@@ -8,19 +18,35 @@
 4. **Test-driven development** - Write tests before implementation
 5. **Git-based distribution** - No PyPI, use GitHub releases
 
+## When to Use This
+
+- Start here before making any change or opening a PR in llm-cli-tools-core.
+- Reference during reviews to verify workflows, tooling, and testing
+  requirements.
+
+## Prerequisites
+
+- Local environment bootstrapped with `just setup`.
+- Access to required secrets for telemetry or GitHub releases when applicable.
+- Node 18+ available locally to run `just docs check` (uses
+  `npx markdownlint-cli2`).
+
 ## 🔧 DEVELOPMENT WORKFLOW
 
 ### Initial Setup
+
 ```bash
 just setup       # Creates UV environment and installs dependencies
 just test        # Verify everything works
 ```
 
 ### Making Changes
+
 1. Create feature branch: `git checkout -b feat/your-feature`
 2. Write tests first (TDD approach)
 3. Implement feature
-4. Run `just ci` to verify everything passes
+4. Run `just ci` to verify everything passes (and `just docs check` if
+   documentation changed)
 5. Commit with conventional message format:
    - `feat:` for new features (triggers minor version bump)
    - `fix:` for bug fixes (triggers patch version bump)
@@ -28,6 +54,7 @@ just test        # Verify everything works
    - Include `BREAKING CHANGE:` for major version bumps
 
 ### Testing
+
 ```bash
 just test           # Run all tests
 just test unit      # Run unit tests only
@@ -35,6 +62,7 @@ just test integration  # Run integration tests only
 ```
 
 ### Linting and Formatting
+
 ```bash
 just lint check     # Check for lint issues
 just lint format    # Auto-format code
@@ -42,7 +70,7 @@ just lint format    # Auto-format code
 
 ## 📦 PACKAGE STRUCTURE
 
-```
+```text
 src/llm_cli_core/
 ├── __init__.py           # Public API exports
 ├── telemetry/            # Telemetry tracking
@@ -62,6 +90,15 @@ src/llm_cli_core/
 - **Minimum 80% coverage** target
 - **Use pytest fixtures** for common setup
 
+## Verification
+
+- Run `just ci` before requesting review to satisfy linting and test coverage
+  expectations.
+- Capture test output in PR descriptions for high-risk changes or failing
+  investigations.
+- `just docs check` now runs markdownlint, cspell, and lychee automatically via
+  `scripts/docs_phase2.sh`; keep Node + Rust toolchain (lychee) available.
+
 ## 🚫 CRITICAL RULES
 
 1. **NEVER hardcode paths** - Use .env configuration
@@ -72,7 +109,7 @@ src/llm_cli_core/
 
 ## 📝 COMMIT MESSAGE CONVENTIONS
 
-```
+```text
 feat: add new provider support
 fix: correct token counting logic
 chore: update dependencies
@@ -86,6 +123,7 @@ BREAKING CHANGE: renamed main API function
 ## 🔄 VERSION MANAGEMENT
 
 Versions are automatically managed by GitHub Actions based on commit messages:
+
 - `feat:` → Minor bump (0.1.0 → 0.2.0)
 - `fix:` → Patch bump (0.1.0 → 0.1.1)
 - `BREAKING CHANGE:` → Major bump (0.1.0 → 1.0.0)
@@ -103,17 +141,20 @@ Versions are automatically managed by GitHub Actions based on commit messages:
 Projects using this library should:
 
 1. Add to dependencies:
-   ```
-   llm-cli-tools-core @ git+https://github.com/spacecargo/llm-cli-tools-core@v0.1.0
+
+   ```text
+   llm-cli-tools-core @ git+https://github.com/degree-analytics/llm-cli-tools-core@v0.1.0
    ```
 
 2. Configure via `.env`:
-   ```
+
+   ```bash
    LLM_TELEMETRY_DIR=.llm-telemetry
    LLM_TELEMETRY_ENABLED=true
    ```
 
 3. Import and use:
+
    ```python
    from llm_cli_core import track_ai_call, OpenRouterTokens
 
@@ -125,6 +166,7 @@ Projects using this library should:
 ## 🚀 FUTURE ENHANCEMENTS
 
 Areas for expansion (not yet implemented):
+
 - [ ] Local storage implementation
 - [ ] Config loading from .env
 - [ ] Provider wrappers (Anthropic, OpenAI)
@@ -136,6 +178,7 @@ Areas for expansion (not yet implemented):
 ## 🤝 HANDOFF NOTES
 
 When handing off to another developer or LLM:
+
 1. The core telemetry code is copied but not yet refactored
 2. Tests are basic but functional
 3. Storage and config modules are stubbed out
@@ -146,6 +189,7 @@ When handing off to another developer or LLM:
 
 - `justfile` - All development commands
 - `pyproject.toml` - Package configuration
-- `src/llm_cli_core/telemetry/core.py` - Main telemetry logic (from ai_telemetry.py)
+- `src/llm_cli_core/telemetry/core.py` - Main telemetry logic (from
+  ai_telemetry.py)
 - `tests/unit/test_telemetry.py` - Basic telemetry tests
 - `.github/workflows/` - CI/CD automation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,7 +158,7 @@ class Config:
 
 Install via:
 
-```
+```bash
 uv pip install "llm-cli-tools-core @ git+https://github.com/degree-analytics/llm-cli-tools-core@v0.1.0"
 ```
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,32 @@
+---
+purpose:
+  "Capture product context, problem framing, and solution scope for
+  llm-cli-tools-core."
+audience: "Contributors, stakeholders, partner teams"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # llm-cli-tools-core - Full Project Context
+
+## When to Use This
+
+- Onboard new collaborators who need the background behind llm-cli-tools-core.
+- Explain strategic decisions to leadership or partner teams.
+
+## Prerequisites
+
+- Familiarity with the downstream repositories (Spacewalker, Mímir) that adopt
+  the library.
+- Access to telemetry metrics or issue tracker history when validating
+  assumptions.
 
 ## 🎯 The Problem We're Solving
 
-We have multiple AI-powered CLI tools across different repositories (spacewalker, mimir, and more coming) that all need the same core functionality:
+We have multiple AI-powered CLI tools across different repositories
+(spacewalker, mimir, and more coming) that all need the same core functionality:
+
 - Telemetry tracking for AI operations
 - Token counting from different providers (OpenRouter, Anthropic, OpenAI)
 - Cost tracking and metrics
@@ -10,10 +34,12 @@ We have multiple AI-powered CLI tools across different repositories (spacewalker
 - Prometheus/Grafana integration
 
 Currently, we have **identical copies** of `ai_telemetry.py` in:
+
 - `/Users/chadwalters/source/work/spacewalker/scripts/helpers/ai_telemetry.py`
 - `/Users/chadwalters/source/work/mimir/src/mimir/core/ai_telemetry.py`
 
 This duplication is problematic because:
+
 1. Bug fixes need to be applied in multiple places
 2. Enhancements aren't shared across projects
 3. Each project might diverge over time
@@ -22,6 +48,7 @@ This duplication is problematic because:
 ## 🚀 The Solution: llm-cli-tools-core
 
 A shared library that provides:
+
 1. **Unified telemetry** for all LLM operations
 2. **Configurable storage** - each project owns its data
 3. **Provider abstraction** - support for OpenRouter, Anthropic, OpenAI, etc.
@@ -30,7 +57,8 @@ A shared library that provides:
 ## 📊 What We Built Today
 
 ### Repository Structure
-```
+
+```text
 llm-cli-tools-core/
 ├── src/llm_cli_core/
 │   ├── telemetry/core.py     # The ai_telemetry.py code (copied, not refactored)
@@ -53,7 +81,8 @@ llm-cli-tools-core/
 
 2. **GitHub as Package Registry**
    - No PyPI account needed
-   - Install via: `uv pip install "llm-cli-tools-core @ git+https://github.com/spacecargo/llm-cli-tools-core@v0.1.0"`
+   - Install via:
+     `uv pip install "llm-cli-tools-core @ git+https://github.com/spacecargo/llm-cli-tools-core@v0.1.0"`
    - Automatic versioning based on commit messages
 
 3. **Per-Project Storage**
@@ -68,6 +97,7 @@ llm-cli-tools-core/
 ## 🎯 Current State
 
 ### What Works ✅
+
 - Package structure is created and valid
 - Telemetry code is copied and imports work
 - Can be installed via git: `uv pip install -e ~/source/work/llm-cli-tools-core`
@@ -78,12 +108,15 @@ llm-cli-tools-core/
 ### What Needs Completion 🔧
 
 #### 1. **Fix Failing Tests** (Priority: HIGH)
+
 - 3 tests fail due to mock path issues
 - The `requests` module is imported inside functions, not at module level
 - Need to fix mock patches to use the correct import path
 
 #### 2. **Refactor Monolithic File** (Priority: MEDIUM)
+
 Currently `telemetry/core.py` has everything. Should be split:
+
 ```python
 # telemetry/extractors.py
 class OpenRouterTokens: ...
@@ -99,6 +132,7 @@ def track_ai_call(): ...
 ```
 
 #### 3. **Implement Storage Layer** (Priority: HIGH)
+
 ```python
 # storage/local.py
 class LocalStorage:
@@ -111,6 +145,7 @@ class StorageBackend(ABC): ...
 ```
 
 #### 4. **Add Configuration System** (Priority: HIGH)
+
 ```python
 # config/settings.py
 class Config:
@@ -122,9 +157,17 @@ class Config:
 ```
 
 #### 5. **Integration Testing** (Priority: MEDIUM)
+
 - Test with real projects (spacewalker, mimir)
 - Ensure backward compatibility
 - Verify storage isolation
+
+## Verification
+
+- Confirm this document reflects the latest architecture decisions during the
+  scheduled quarterly review.
+- Cross-check downstream repositories (Spacewalker, Mímir) after major releases
+  to ensure assumptions remain accurate.
 
 ## 🎯 Success Criteria
 
@@ -146,6 +189,7 @@ After the initial release, we want to add:
    - Pattern recognition
 
 2. **Provider Wrappers**
+
    ```python
    from llm_cli_core.providers import AnthropicProvider
 
@@ -180,7 +224,8 @@ After the initial release, we want to add:
 
 When you read this, consider:
 
-1. **Storage Format**: Should we use JSON, SQLite, or something else for local storage?
+1. **Storage Format**: Should we use JSON, SQLite, or something else for local
+   storage?
 2. **Naming**: Is `llm-cli-tools-core` the best name, or should it be simpler?
 3. **Scope**: Should v0.1.0 include storage, or just fix the telemetry?
 4. **Testing**: What level of test coverage is acceptable for v0.1.0?
@@ -197,21 +242,26 @@ When you read this, consider:
 ## 🎯 The Ask
 
 Please:
+
 1. Read this context and the CLAUDE.md file
 2. Ask any clarifying questions you have
 3. Fix the failing tests first (mock path issues)
 4. Then proceed with refactoring and enhancements
 5. Keep changes minimal for v0.1.0 - we can add features later
 
-The goal is a **working, installable package** that eliminates code duplication across our projects. Everything else can be added incrementally.
+The goal is a **working, installable package** that eliminates code duplication
+across our projects. Everything else can be added incrementally.
 
 ## 💡 Why This Matters
 
-We're building more AI tools all the time. Having a solid foundation for telemetry, storage, and configuration means:
+We're building more AI tools all the time. Having a solid foundation for
+telemetry, storage, and configuration means:
+
 - Consistent metrics across all tools
 - Better understanding of AI usage and costs
 - Ability to mine prompts and improve quality
 - Faster development of new tools
 - Single place to fix bugs and add features
 
-This is infrastructure that will pay dividends as we scale our AI tooling ecosystem.
+This is infrastructure that will pay dividends as we scale our AI tooling
+ecosystem.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -156,6 +156,12 @@ class Config:
         # ... etc
 ```
 
+Install via:
+
+```
+uv pip install "llm-cli-tools-core @ git+https://github.com/degree-analytics/llm-cli-tools-core@v0.1.0"
+```
+
 #### 5. **Integration Testing** (Priority: MEDIUM)
 
 - Test with real projects (spacewalker, mimir)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
+---
+purpose:
+  "Document llm-cli-tools-core capabilities, installation, and quick start
+  usage."
+audience: "Developers, integrators, and maintainers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # llm-cli-tools-core
 
-Core telemetry and utilities for LLM CLI tools. Provides unified telemetry tracking, storage, and configuration for AI-powered command-line tools.
+Core telemetry and utilities for LLM CLI tools. Provides unified telemetry
+tracking, storage, and configuration for AI-powered command-line tools.
+
+## When to Use This
+
+- Consolidate telemetry, cost, and token accounting across AI-driven CLIs.
+- Share a single instrumentation library between repositories such as
+  Spacewalker and Mímir.
+
+## Prerequisites
+
+- Python 3.11 or newer with [`uv`](https://docs.astral.sh/uv/) installed.
+- Read access to the GitHub repository releases (or main branch) when
+  installing.
 
 ## Features
 
@@ -15,6 +38,7 @@ Core telemetry and utilities for LLM CLI tools. Provides unified telemetry track
 ## Installation
 
 ### From GitHub Release (Recommended)
+
 ```bash
 # Install specific version
 uv pip install "llm-cli-tools-core @ git+https://github.com/degree-analytics/llm-cli-tools-core@v0.1.0"
@@ -24,8 +48,9 @@ uv pip install "llm-cli-tools-core @ git+https://github.com/degree-analytics/llm
 ```
 
 ### For Development
+
 ```bash
-git clone https://github.com/spacecargo/llm-cli-tools-core
+git clone https://github.com/degree-analytics/llm-cli-tools-core
 cd llm-cli-tools-core
 just setup          # Set up development environment
 just test           # Run tests
@@ -35,6 +60,7 @@ just install-local  # Install in editable mode
 ## Quick Start
 
 ### Basic Usage
+
 ```python
 from llm_cli_core import track_ai_call, OpenRouterTokens
 
@@ -50,6 +76,7 @@ with track_ai_call("my-agent", "document-search") as tracker:
 ```
 
 ### Different Provider Support
+
 ```python
 # OpenRouter
 from llm_cli_core import OpenRouterTokens
@@ -65,6 +92,7 @@ tracker.record_tokens(OpenAITokens(openai_response_json))
 ```
 
 ### Legacy Compatibility
+
 ```python
 from llm_cli_core import send_agent_metrics
 
@@ -77,6 +105,13 @@ send_agent_metrics(
     cost_usd=0.002
 )
 ```
+
+## Verification
+
+- Run `just test` before publishing changes to confirm the telemetry suite
+  passes.
+- Execute the quick start example against a sandbox provider and confirm metrics
+  are recorded as expected.
 
 ## Configuration
 
@@ -104,6 +139,7 @@ CLAUDE_USER_ID=                          # Optional: Override user ID
 ## Development
 
 ### Setup Development Environment
+
 ```bash
 # Clone the repository
 git clone https://github.com/spacecargo/llm-cli-tools-core
@@ -125,9 +161,12 @@ just ci
 
 ### GitHub App Access For CI
 
-Org repositories that need read access to `llm-cli-tools-core` via GitHub Actions should follow the shared GitHub App setup described in `docs/development/github-app-integration.md`.
+Org repositories that need read access to `llm-cli-tools-core` via GitHub
+Actions should follow the shared GitHub App setup described in
+`docs/development/github-app-integration.md`.
 
 ### Running Tests
+
 ```bash
 just test           # Run all tests
 just test unit      # Run unit tests only
@@ -136,9 +175,10 @@ just test integration  # Run integration tests
 
 ## Telemetry Storage
 
-Telemetry is stored as newline-delimited JSON in the configured directory (default: `.llm-telemetry/`).
+Telemetry is stored as newline-delimited JSON in the configured directory
+(default: `.llm-telemetry/`).
 
-```
+```text
 .llm-telemetry/
 ├── 2025-01-27/
 │   └── telemetry.jsonl       # One record per AI call
@@ -147,7 +187,8 @@ Telemetry is stored as newline-delimited JSON in the configured directory (defau
 └── summary.json              # Rolling totals (cost, tokens, per-agent/model)
 ```
 
-Prompts/responses are written to `prompts.jsonl` and `responses.jsonl` only when explicitly enabled via `LLM_STORE_PROMPTS` / `LLM_STORE_RESPONSES`.
+Prompts/responses are written to `prompts.jsonl` and `responses.jsonl` only when
+explicitly enabled via `LLM_STORE_PROMPTS` / `LLM_STORE_RESPONSES`.
 
 ## CLI Analytics
 
@@ -161,29 +202,42 @@ llm-telemetry costs
 llm-telemetry costs --json
 
 # Filter by project, agent, status, or model
-llm-telemetry costs --project spacewalker --agent doc-finder --status success --days 7
+llm-telemetry costs --project spacewalker --agent doc-finder \
+  --status success --days 7
 ```
 
-Output includes total cost, total tokens, and breakdowns by model and agent. Pricing data is cached locally and refreshed automatically (at most once every 7 days).
+Output includes total cost, total tokens, and breakdowns by model and agent.
+Pricing data is cached locally and refreshed automatically (at most once every 7
+days).
 
 ## GitHub Automation
 
-This repository ships the same Claude and Codex review automation used in our other projects:
+This repository ships the same Claude and Codex review automation used in our
+other projects:
 
-- `.github/workflows/claude.yml` – trigger with `@claude` or `/claude` comments to request targeted AI reviews (docs, correctness, overengineering, justfile). Requires Anthropic API credentials (`ANTHROPIC_API_KEY`, optional secrets described in the workflow) and supports manual `workflow_dispatch` runs.
-- `.github/workflows/codex-review.yml` – trigger with `@codex` or `/codex` comments for GPT-based reviews. Requires `OPENAI_API_KEY` and posts sticky summaries plus inline comments.
+- `.github/workflows/claude.yml` – trigger with `@claude` or `/claude` comments
+  to request targeted AI reviews (docs, correctness, overengineering, justfile).
+  Requires Anthropic API credentials (`ANTHROPIC_API_KEY`, optional secrets
+  described in the workflow) and supports manual `workflow_dispatch` runs.
+- `.github/workflows/codex-review.yml` – trigger with `@codex` or `/codex`
+  comments for GPT-based reviews. Requires `OPENAI_API_KEY` and posts sticky
+  summaries plus inline comments.
 
-Both workflows rely on repository/organization variables (e.g. `CLAUDE_MAX_TURNS`) and secrets mirroring the Spacewalker setup. Copy those values into this repo before enabling the automations.
+Both workflows rely on repository/organization variables (e.g.
+`CLAUDE_MAX_TURNS`) and secrets mirroring the Spacewalker setup. Copy those
+values into this repo before enabling the automations.
 
 For day-to-day usage tips and GT/Claude best practices, see:
 
-- `docs/claude-components/deployment-gt-workflow.md` – required GT branching workflow
-- `docs/development/claude-commands.md` – available slash commands (including Ground Truth)
+- `docs/claude-components/deployment-gt-workflow.md` – required GT branching
+  workflow
+- `docs/development/claude-commands.md` – available slash commands (including
+  Ground Truth)
 - `docs/workflows/claude-review-workflows.md` – how multi-focus reviews operate
 
 ## Architecture
 
-```
+```text
 llm-cli-tools-core/
 ├── analytics/              # Aggregations used by the CLI
 │   └── costs.py
@@ -207,6 +261,7 @@ llm-cli-tools-core/
 6. Push to your fork and create a Pull Request
 
 ### Commit Message Format
+
 - `feat:` - New features (triggers minor version bump)
 - `fix:` - Bug fixes (triggers patch version bump)
 - `chore:` - Maintenance tasks (no version bump)
@@ -233,7 +288,8 @@ LLM_PUSHGATEWAY_URL=http://localhost:9101
 ```
 
 Metrics format:
-```
+
+```text
 ai_agent_usage_total{agent_name="...", operation="...", model="..."}
 ai_agent_tokens_total{agent_name="...", model="..."}
 ai_agent_cost_usd_total{agent_name="...", model="..."}
@@ -247,7 +303,9 @@ MIT
 ## Support
 
 For issues and questions:
-- Open an issue on [GitHub](https://github.com/spacecargo/llm-cli-tools-core/issues)
+
+- Open an issue on
+  [GitHub](https://github.com/degree-analytics/llm-cli-tools-core/issues)
 - Check the [CLAUDE.md](CLAUDE.md) for development guidelines
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ CLAUDE_USER_ID=                          # Optional: Override user ID
 
 ```bash
 # Clone the repository
-git clone https://github.com/spacecargo/llm-cli-tools-core
+git clone https://github.com/degree-analytics/llm-cli-tools-core
 cd llm-cli-tools-core
 
 # Set up UV environment

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,30 @@
+version: "0.2"
+language: en
+words:
+  - Mímir
+  - openrouter
+  - pushgateway
+  - Pushgateway
+  - PUSHGATEWAY
+  - overengineering
+  - justfile
+  - automations
+  - dataclass
+  - Groundtruth
+  - Claude
+  - Spacewalker
+  - pytest
+  - pyproject
+  - chadwalters
+  - getenv
+  - commandname
+  - fastapi
+  - Runbook
+  - anthropics
+  - MTOK
+flagWords: []
+ignorePaths:
+  - "**/node_modules/**"
+  - "**/.git/**"
+  - "**/dist/**"
+  - "**/.cache/**"

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -21,6 +21,9 @@ words:
   - fastapi
   - Runbook
   - anthropics
+  - Quickstart
+  - Runbooks
+  - Frontmatter
   - MTOK
 flagWords: []
 ignorePaths:

--- a/docs/claude-components/deployment-gt-workflow.md
+++ b/docs/claude-components/deployment-gt-workflow.md
@@ -1,11 +1,35 @@
+---
+purpose:
+  "Define mandatory GT-based deployment rules for code and infrastructure
+  changes."
+audience: "Developers, release managers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # 📦 DEPLOYMENT WORKFLOW RULES
 
 **CRITICAL**: Different types of changes follow different deployment paths:
 
-## Code Changes (apps/, scripts/, packages/):
+## When to Use This
+
+- Plan or review any deployment for Spacewalker, Mímir, or shared libraries that
+  rely on GT workflows.
+- Audit release readiness before approving production merges.
+
+## Prerequisites
+
+- `gt` CLI installed and authenticated.
+- Access to required AWS or infrastructure credentials when executing deployment
+  commands.
+
+## Code Changes (apps/, scripts/, packages/)
+
 1. **ALWAYS use GT workflow** → Create branch → PR to dev → Test → PR to main
 2. **NEVER deploy code directly** to production without PR review
 3. **Workflow**:
+
    ```bash
    gt create --all -m "fix: description"  # Create branch
    gt submit                              # Create PR to dev
@@ -15,9 +39,10 @@
    gt submit                              # Create PR to main
    ```
 
-## Infrastructure Changes (sam/, CloudFormation):
+## Infrastructure Changes (sam/, CloudFormation)
+
 1. **Dev environment**: Can use `just aws_deploy_* dev` directly
-2. **Prod environment**: 
+2. **Prod environment**:
    - If changing running services → Follow code workflow (PR first)
    - If only infrastructure → Can deploy directly with approval
 3. **Examples**:
@@ -26,13 +51,23 @@
    - Changing health checks → PR workflow (affects service behavior)
 
 ## GT ESSENTIALS (Minimal Reminders)
+
 **Core Rule**: Use `gt` for branches, never `git`
+
 - Before ANY operation: `git status && gt log --stack`
 
 ## 🚨 CRITICAL GT RESTACK RULES
+
 **NEVER use rebase during gt restack operations!**
+
 - When `gt restack` shows merge conflicts → Use merge resolution, NOT rebase
 - FORBIDDEN: `git rebase` during any GT workflow
 - REQUIRED: Let GT handle the merge strategy
 - If tempted to rebase → STOP and ask user for guidance
 - Rebase breaks GT's internal tracking and causes cascading conflicts
+
+## Verification
+
+- Capture `gt status` and `gt log --stack` output before and after the
+  deployment sequence to confirm history integrity.
+- Ensure both dev and main PRs show successful CI runs prior to merging.

--- a/docs/development/claude-commands.md
+++ b/docs/development/claude-commands.md
@@ -1,29 +1,57 @@
+---
+purpose: "Catalog shared Claude slash commands and describe when to apply them."
+audience: "Developers, reviewers, automation engineers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # Claude Commands Guide
 
-This guide documents the available Claude slash commands in SpaceWalker and how to create custom commands.
+This guide documents the available Claude slash commands in SpaceWalker and how
+to create custom commands.
 
 ## Overview
 
-Claude commands are markdown files in `.claude/commands/` that define reusable workflows and automation scripts. They help standardize common tasks and ensure consistent execution.
+Claude commands are markdown files in `.claude/commands/` that define reusable
+workflows and automation scripts. They help standardize common tasks and ensure
+consistent execution.
+
+## When to Use This
+
+- Invoke standardized automation in Claude chats without recalling justfile
+  syntax.
+- Review command behavior before editing or adding new slash commands.
+
+## Prerequisites
+
+- Repository clone with `.claude/commands/` available.
+- Access to Claude with slash command support.
 
 ## Available Commands
 
 ### Core Workflow Commands
 
 #### `/commit`
+
 Commits changes following project standards with verification.
+
 - Runs linting and tests before committing
 - Follows conventional commit format
 - Includes co-author attribution
 
 #### `/complete-next-task`
+
 Executes the next task from TaskMaster with full verification.
+
 - Updates task status throughout execution
 - Runs appropriate tests
 - Documents verification results
 
 #### `/init-context`
+
 Loads project context at the start of a session.
+
 - Reads CLAUDE.md instructions
 - Loads relevant documentation
 - Sets up for current branch/task
@@ -31,7 +59,9 @@ Loads project context at the start of a session.
 ### PR and Review Commands
 
 #### `/review-pr-comments`
+
 Analyzes PR comments and provides numbered action items for easy selection.
+
 - Uses pr-review-analyzer agent with `just gh-pr comments`
 - Presents actionable feedback as numbered items
 - Supports flexible selection (e.g., "1,3" or "all")
@@ -45,13 +75,17 @@ Analyzes PR comments and provides numbered action items for easy selection.
 ```
 
 #### `/request-review`
+
 Updates PR description and requests review.
+
 - Summarizes changes made
 - Updates PR body
 - Can request specific reviewers
 
 #### `/generate-pr-title-description`
+
 Creates PR title and description from changes.
+
 - Analyzes git diff
 - Follows PR template
 - Links to Linear tickets
@@ -59,19 +93,25 @@ Creates PR title and description from changes.
 ### Development Commands
 
 #### `/fix-linear-issue <issue-id>`
+
 Complete workflow for fixing a Linear issue.
+
 - Creates branch
 - Updates task status
 - Implements fix with verification
 
 #### `/create-tasks-from-linear`
+
 Imports Linear issues into TaskMaster.
+
 - Fetches assigned issues
 - Creates local tasks
 - Sets priorities
 
 #### `/update-linear-ticket`
+
 Syncs PR progress back to Linear.
+
 - Updates issue status
 - Adds PR link
 - Posts progress comments
@@ -79,25 +119,33 @@ Syncs PR progress back to Linear.
 ### Release Management
 
 #### `/changelog-add`
+
 Adds entry to changelog following keep-a-changelog format.
+
 - Categorizes changes correctly
 - Maintains format consistency
 - Prepares for release
 
 #### `/changelog-release`
+
 Prepares changelog for release.
+
 - Moves unreleased to version section
 - Updates version numbers
 - Creates release commit
 
 #### `/version-bump`
+
 Updates version numbers across the project.
+
 - Updates package.json files
 - Updates version constants
 - Maintains consistency
 
 #### `/smart-dev-to-main`
+
 Orchestrates dev→main merge workflow.
+
 - Ensures CI passing
 - Creates merge PR
 - Handles deployment
@@ -105,19 +153,25 @@ Orchestrates dev→main merge workflow.
 ### Utility Commands
 
 #### `/create-command`
+
 Creates a new Claude command from template.
+
 - Interactive command builder
 - Follows command patterns
 - Adds to commands directory
 
 #### `/cleanup-docs-justfile`
+
 Reviews and updates documentation after development.
+
 - Identifies outdated docs
 - Suggests justfile commands
 - Updates INDEX.md
 
 #### `/analyze-ci-failure`
+
 Investigates CI/CD failures with detailed analysis.
+
 - Fetches failure logs
 - Identifies root causes
 - Suggests fixes
@@ -134,26 +188,31 @@ The TaskMaster suite provides comprehensive task management:
 /tm/workflows/daily  # Daily standup workflow
 ```
 
-See `@.claude/TM_COMMANDS_GUIDE.md` for complete TaskMaster documentation.
+See the internal TaskMaster guide (`@.claude/TM_COMMANDS_GUIDE.md`) for complete
+documentation.
 
 ## Command Structure
 
 Each command file follows this structure:
 
-```markdown
+````markdown
 # Command Name
 
 Brief description of what the command does.
 
 ## Usage
-```
+
+```bash
 /command-name [required-arg] [optional-arg]
 ```
+````
 
 ## Purpose
+
 Detailed explanation of when and why to use this command.
 
-## Implementation
+## Implementation Template
+
 Step-by-step workflow the command follows:
 
 1. **Phase 1**: Description
@@ -165,14 +224,16 @@ Step-by-step workflow the command follows:
    - Verification steps
 
 ## Examples
+
 Concrete usage examples with expected outcomes.
 
 ## Safety Considerations
+
 Any warnings or safety checks.
 
 ## Related Commands
+
 Links to similar or complementary commands.
-```
 
 ## Creating Custom Commands
 
@@ -194,27 +255,29 @@ touch .claude/commands/my-command.md
 What this command does.
 
 ## Usage
-```
-/my-command <required> [optional]
+
+    /my-command {required} [optional]
 ```
 
 ## Implementation
 
 ### Phase 1: Setup
+
 1. Validate inputs
 2. Check prerequisites
 3. Load necessary context
 
 ### Phase 2: Execution
+
 1. Main logic here
 2. Use appropriate tools
 3. Verify results
 
 ### Phase 3: Cleanup
+
 1. Update documentation
 2. Commit changes
 3. Report results
-```
 
 ### 3. Command Best Practices
 
@@ -227,6 +290,7 @@ What this command does.
 ### 4. Testing Commands
 
 Before adding to the repository:
+
 1. Test with various inputs
 2. Verify safety checks work
 3. Ensure idempotency where possible
@@ -235,21 +299,27 @@ Before adding to the repository:
 ## Command Patterns
 
 ### Workflow Commands
+
 Commands that orchestrate multi-step processes:
+
 - Start with context gathering
 - Execute in clear phases
 - Include verification between phases
 - End with cleanup/documentation
 
 ### Analysis Commands
+
 Commands that provide insights:
+
 - Fetch data from multiple sources
 - Process and correlate information
 - Present actionable findings
 - Suggest next steps
 
 ### Automation Commands
+
 Commands that automate repetitive tasks:
+
 - Replace manual command sequences
 - Include error handling
 - Provide progress feedback
@@ -258,15 +328,24 @@ Commands that automate repetitive tasks:
 ## Integration with Project Workflows
 
 Commands integrate with:
+
 - **TaskMaster** - Task tracking and status updates
 - **Justfile** - Standardized command execution
 - **Git/GT** - Version control operations
 - **Linear** - Issue tracking synchronization
 - **CI/CD** - Build and deployment automation
 
+## Verification
+
+- Run `/commit --help` (or another command) in Claude and confirm the
+  descriptions match this guide.
+- Ensure new or updated commands include runnable examples before merging
+  related changes.
+
 ## Troubleshooting
 
 ### Command Not Found
+
 ```bash
 # List all commands
 ls -la .claude/commands/
@@ -276,12 +355,14 @@ ls .claude/commands/ | grep -i commandname
 ```
 
 ### Command Fails
+
 1. Check prerequisites (API keys, tools installed)
 2. Verify current directory is project root
 3. Review command implementation for issues
 4. Check related tool availability
 
 ### Creating Command Issues
+
 - Ensure markdown formatting is valid
 - Check file permissions
 - Verify command doesn't conflict with existing ones
@@ -289,6 +370,7 @@ ls .claude/commands/ | grep -i commandname
 ## Future Enhancements
 
 Potential improvements for the command system:
+
 - Command aliases for common variations
 - Parameter validation framework
 - Command composition/chaining
@@ -297,6 +379,8 @@ Potential improvements for the command system:
 
 ## Related Documentation
 
-- [TaskMaster Guide](@.claude/TM_COMMANDS_GUIDE.md) - Complete task management
-- [Justfile Workflow](../claude-components/justfile-workflow.md) - Using just commands
-- [Development Setup](../setup/development-setup.md) - Environment configuration
+- TaskMaster Guide (`@.claude/TM_COMMANDS_GUIDE.md`) - Complete task management
+- Justfile Workflow – Reference the core Spacewalker justfile patterns for
+  command usage.
+- Development Setup – Follow the repository README/CLAUDE instructions for
+  local environment configuration.

--- a/docs/development/claude-context-management.md
+++ b/docs/development/claude-context-management.md
@@ -1,26 +1,48 @@
+---
+purpose:
+  "Describe the modular CLAUDE.md context hierarchy and how to extend it."
+audience: "Developers configuring AI instructions, reviewers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # CLAUDE.md Context Management System
 
 ## Purpose
-Comprehensive guide to the modular AI context management system using @ file references, nested inheritance, and domain-specific context organization for enhanced AI development workflows.
+
+Comprehensive guide to the modular AI context management system using @ file
+references, nested inheritance, and domain-specific context organization for
+enhanced AI development workflows.
 
 ## When to Use This
+
 - Setting up AI context for new projects or domains
 - Understanding how Claude Code processes context hierarchies
 - Implementing modular, reusable instruction sets
 - Debugging context loading or inheritance issues
 - Maintaining consistent AI behavior across team members
 
-**Keywords:** CLAUDE.md, context management, AI instructions, file references, inheritance
+## Prerequisites
+
+- Access to the repository's `CLAUDE.md` files and referenced components.
+- Working knowledge of the `@` include syntax and directory structure
+  conventions.
+
+**Keywords:** CLAUDE.md, context management, AI instructions, file references,
+inheritance
 
 ---
 
 ## 🌟 System Overview
 
-The Spacewalker project implements a sophisticated AI context management system that provides:
+The Spacewalker project implements a sophisticated AI context management system
+that provides:
 
 - **Modular Components**: Reusable instruction sets via @ file references
 - **Domain Inheritance**: Nested CLAUDE.md files for specialized contexts
-- **Personal Preferences**: User-specific configurations separate from project rules
+- **Personal Preferences**: User-specific configurations separate from project
+  rules
 - **Automatic Discovery**: Claude Code's recursive directory traversal
 
 ### Architecture Benefits
@@ -34,7 +56,7 @@ The Spacewalker project implements a sophisticated AI context management system 
 
 ## 📁 Directory Structure
 
-```
+```text
 spacewalker/
 ├── CLAUDE.md                           # Root context with @ references
 ├── docs/claude-components/             # Reusable instruction components
@@ -64,16 +86,19 @@ spacewalker/
 
 ### How It Works
 
-1. **Claude Code Processing**: Automatically expands @ references during context loading
+1. **Claude Code Processing**: Automatically expands @ references during context
+   loading
 2. **Relative Paths**: All paths relative to current CLAUDE.md location
 3. **Content Injection**: Referenced content inserted at @ reference location
-4. **Recursive Processing**: @ references within referenced files are also expanded
+4. **Recursive Processing**: @ references within referenced files are also
+   expanded
 
 ### Best Practices
 
 - **Place @ references early**: Load shared rules before specific overrides
 - **Use descriptive filenames**: Component purpose should be clear from name
-- **Maintain flat structure**: Keep components in single directory for simplicity
+- **Maintain flat structure**: Keep components in single directory for
+  simplicity
 - **Document dependencies**: Note when components depend on each other
 
 ---
@@ -83,9 +108,11 @@ spacewalker/
 ### Current Components
 
 #### `docs/claude-components/safety-rules.md`
+
 **Purpose**: Universal safety patterns for production, git, and AWS operations
 
 **Key Rules**:
+
 - Never run production commands without permission
 - Git read-only restrictions (status, diff only)
 - AWS resource protection
@@ -94,9 +121,11 @@ spacewalker/
 **When to Update**: New safety requirements, security policy changes
 
 #### `docs/claude-components/justfile-workflow.md`
+
 **Purpose**: Automation-first development patterns and command discovery
 
 **Key Rules**:
+
 - Justfile-first approach for all operations
 - Standard command naming and organization
 - Workflow automation principles
@@ -104,9 +133,11 @@ spacewalker/
 **When to Update**: New automation patterns, justfile enhancements
 
 #### `docs/claude-components/verification-standards.md`
+
 **Purpose**: Testing and validation requirements for task completion
 
 **Key Rules**:
+
 - Never claim "done" without verification
 - Required verification methods (tests, manual validation)
 - TaskMaster integration patterns
@@ -114,9 +145,11 @@ spacewalker/
 **When to Update**: New testing frameworks, validation requirements
 
 #### `docs/claude-components/deployment-gt-workflow.md`
+
 **Purpose**: Git workflow patterns and deployment procedures
 
 **Key Rules**:
+
 - GT CLI usage patterns
 - Branch management workflows
 - Deployment safety protocols
@@ -125,7 +158,8 @@ spacewalker/
 
 ### Creating New Components
 
-1. **Identify Reusable Patterns**: Look for instruction sets used across multiple domains
+1. **Identify Reusable Patterns**: Look for instruction sets used across
+   multiple domains
 2. **Extract to Component**: Create focused, single-purpose instruction file
 3. **Update References**: Add @ reference to all relevant CLAUDE.md files
 4. **Test Inheritance**: Verify component loads correctly in all contexts
@@ -137,9 +171,10 @@ spacewalker/
 
 ### How Inheritance Works
 
-Claude Code automatically discovers CLAUDE.md files by traversing up the directory tree:
+Claude Code automatically discovers CLAUDE.md files by traversing up the
+directory tree:
 
-```
+```text
 1. Current directory: apps/backend/CLAUDE.md
 2. Parent directory: spacewalker/CLAUDE.md
 3. Home directory: ~/.claude/CLAUDE.md (if exists)
@@ -148,16 +183,19 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 ### Context Layering Strategy
 
 **Layer 1: Personal Preferences** (`~/.claude/CLAUDE.md`)
+
 - Individual developer preferences
 - Personal shortcuts and patterns
 - Development environment customizations
 
 **Layer 2: Project Root** (`CLAUDE.md`)
+
 - Universal project rules and safety
 - Shared component references
 - Project-wide patterns
 
 **Layer 3: Domain Specific** (`apps/*/CLAUDE.md`, `sam/CLAUDE.md`)
+
 - Technology-specific patterns
 - Domain workflows and standards
 - Specialized testing and deployment rules
@@ -176,12 +214,14 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 ### Backend Context (`apps/backend/CLAUDE.md`)
 
 **Focus Areas**:
+
 - Python/FastAPI patterns
 - Database and migration workflows
 - API design standards (no trailing slashes!)
 - Authentication and security patterns
 
 **Key Sections**:
+
 - Code standards and type hints
 - Database testing with RLS verification
 - Async patterns and error handling
@@ -189,12 +229,14 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 ### Admin Context (`apps/admin/CLAUDE.md`)
 
 **Focus Areas**:
+
 - React/Next.js development patterns
 - Component architecture standards
 - UI/UX consistency patterns
 - Client-side testing approaches
 
 **Key Sections**:
+
 - TypeScript usage requirements
 - Material-UI component consistency
 - State management patterns
@@ -202,12 +244,14 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 ### Mobile Context (`apps/mobile/CLAUDE.md`)
 
 **Focus Areas**:
+
 - React Native/Expo patterns
 - Mobile-specific API integration
 - Build and deployment workflows
 - Device-specific considerations
 
 **Key Sections**:
+
 - Offline-first architecture
 - Performance optimization
 - Platform-specific testing
@@ -215,12 +259,14 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 ### Infrastructure Context (`sam/CLAUDE.md`)
 
 **Focus Areas**:
+
 - CloudFormation/SAM patterns
 - AWS deployment procedures
 - Infrastructure security
 - Monitoring and observability
 
 **Key Sections**:
+
 - Resource naming conventions
 - Environment management
 - Deployment order requirements
@@ -231,29 +277,37 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 
 ### Setup Location: `~/.claude/CLAUDE.md`
 
-**Note**: ENG-679 originally specified `CLAUDE.local.md`, but Claude Code documentation shows that personal preferences should use `~/.claude/CLAUDE.md` instead. This file is automatically discovered by Claude Code's recursive directory traversal and is naturally excluded from git repositories.
+**Note**: ENG-679 originally specified `CLAUDE.local.md`, but Claude Code
+documentation shows that personal preferences should use `~/.claude/CLAUDE.md`
+instead. This file is automatically discovered by Claude Code's recursive
+directory traversal and is naturally excluded from git repositories.
 
 **Personal preferences should include**:
+
 - Individual coding style preferences
 - Preferred debugging approaches
 - Personal shortcuts and aliases
 - Development environment specifics
 
 **Example Personal Preferences**:
+
 ```markdown
 # Personal Development Preferences
 
 ## Debugging Style
+
 - Prefer verbose logging during development
 - Use step-through debugging for complex issues
 - Include performance timing in development builds
 
 ## Code Organization
+
 - Prefer explicit imports over wildcard imports
 - Use descriptive variable names over short forms
 - Include TODO comments for future improvements
 
 ## Development Workflow
+
 - Always run full test suite before committing
 - Use git hooks for automated formatting
 - Prefer feature branches for all work
@@ -273,12 +327,14 @@ Claude Code automatically discovers CLAUDE.md files by traversing up the directo
 ### Regular Maintenance Tasks
 
 **Monthly Review**:
+
 - Check for outdated instructions in components
 - Verify @ references are still valid
 - Update domain contexts for new patterns
 - Review personal preferences for relevance
 
 **After Major Changes**:
+
 - Update affected components
 - Test context loading in all domains
 - Verify inheritance works correctly
@@ -308,17 +364,20 @@ cd sam && claude --context-check
 
 ### Common Issues
 
-**@ Reference Not Found**
+#### @ Reference Not Found
+
 - Check file path is relative to CLAUDE.md location
 - Verify file exists and is readable
 - Ensure no typos in filename
 
-**Context Not Loading**
+#### Context Not Loading
+
 - Verify CLAUDE.md file is in expected location
 - Check file permissions
 - Test with minimal CLAUDE.md to isolate issue
 
-**Inheritance Not Working**
+#### Inheritance Not Working
+
 - Confirm you're in correct directory
 - Check for syntax errors in parent CLAUDE.md files
 - Verify Claude Code version supports inheritance
@@ -376,23 +435,39 @@ claude --show-inheritance
 
 ---
 
+## Verification
+
+- Expand the root `CLAUDE.md` with Claude Code to confirm all `@` references
+  resolve without errors.
+- Spot-check a domain-specific `CLAUDE.md` to ensure inheritance produces the
+  expected combined instructions.
+
 ## 🔗 Related Documentation
 
 ### Context System Architecture
-- **[Project Structure](./project-structure.md)** - Overall project organization
-- **[Development Tools](./development-tools.md)** - Claude Code setup and usage
+
+- **Project Structure** – See the Spacewalker documentation for full repository
+  layout guidance.
+- **Development Tools** – Refer to the Spacewalker development tools guide for
+  Claude Code setup and usage.
 
 ### Domain-Specific Guides
-- **[Backend API Development](../backend/api-development.md)** - Backend context patterns
-- **[Admin Development](../admin/architecture/)** - Frontend context patterns
-- **[Mobile Development](../mobile/development-patterns.md)** - Mobile context patterns
+
+- **Backend API Development** – Follow the Spacewalker backend API context
+  patterns.
+- **Admin Development** – See the Spacewalker admin architecture guide for
+  frontend context patterns.
+- **Mobile Development** – Consult the Spacewalker mobile development patterns
+  guidance.
 
 ### Workflow Integration
-- **[TaskMaster Commands](/tm/help)** - AI-powered project management
-- **[Testing Guide](../workflows/testing-guide.md)** - Verification standards implementation
+
+- **TaskMaster Commands** – Internal TaskMaster help (`@tm/help`) for AI-powered
+  project management.
+- **Testing Guide** – Spacewalker workflow guidance for verification standards
+  implementation.
 
 ---
 
-**Last Updated:** 2025-07-08
-**Status:** Current
-**Maintainer:** Development Team
+**Last Updated:** 2025-07-08 **Status:** Current **Maintainer:** Development
+Team

--- a/docs/development/claude-hooks-setup.md
+++ b/docs/development/claude-hooks-setup.md
@@ -1,16 +1,40 @@
+---
+purpose:
+  "Explain how to enable and validate Claude Code project hooks for
+  Spacewalker-derived repositories."
+audience:
+  "Developers and automation engineers using Claude Code with llm-cli-tools-core"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # 🪝 Claude Code Hooks Setup Guide
 
-**SpaceWalker includes project-specific Claude Code hooks for enhanced development workflow.**
+**SpaceWalker includes project-specific Claude Code hooks for enhanced
+development workflow.**
 
 ## Overview
 
 Our hooks provide:
+
 - **Lint-on-Save**: Instant feedback when editing code files
 - **Search Year Update**: Automatically updates outdated years in web searches
+
+## When to Use This
+
+- Local Claude Code sessions need the repository-specific automation.
+- Hooks stop triggering and you need to verify expected files.
+
+## Prerequisites
+
+- Clone of the repository with `.claude/hooks/` checked in.
+- Claude Code or Claude Desktop with project hook execution enabled.
 
 ## Quick Setup
 
 ### 1. Verify Hook Files Exist
+
 ```bash
 ls .claude/hooks/
 # Should show:
@@ -23,25 +47,31 @@ ls .claude/settings.json
 
 ### 2. Enable Project Hooks in Claude Code
 
-Claude Code automatically detects and uses project-specific settings when working in this repository. **No additional setup required!**
+Claude Code automatically detects and uses project-specific settings when
+working in this repository. **No additional setup required!**
 
 The hooks are enabled by default when you work in the SpaceWalker directory.
 
 ## How It Works
 
 ### Lint-on-Save Hook
-- **Trigger**: When you edit/write Python (.py) or TypeScript (.ts/.tsx/.js/.jsx) files
+
+- **Trigger**: When you edit/write Python (.py) or TypeScript
+  (.ts/.tsx/.js/.jsx) files
 - **Action**: Runs `just lint check <module> --files <filename>`
 - **Output**: Shows warnings for lint issues (never blocks saves)
-- **Performance**: <500ms execution (0.5s timeout in settings), only checks the single edited file
+- **Performance**: <500ms execution (0.5s timeout in settings), only checks the
+  single edited file
 
 **Example**:
-```
+
+```text
 ⚠️  main.py:
 apps/backend/src/main.py:15:1: F401 'os' imported but unused
 ```
 
 ### Search Year Update Hook
+
 - **Trigger**: When you use WebSearch tool
 - **Action**: Updates outdated years (2024 and older) to current/range
 - **Logic**:
@@ -51,7 +81,8 @@ apps/backend/src/main.py:15:1: F401 'os' imported but unused
 - **Performance**: <100ms execution (0.1s timeout in settings)
 
 **Example**:
-```
+
+```text
 Query: "fastapi docs 2024"
 Updated: "fastapi docs 2024-2025"
 📅 Updated: 2024 → 2024-2025
@@ -60,6 +91,7 @@ Updated: "fastapi docs 2024-2025"
 ## Hook Configuration
 
 ### Project Settings (`.claude/settings.json`)
+
 ```json
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
@@ -71,7 +103,7 @@ Updated: "fastapi docs 2024-2025"
           {
             "type": "command",
             "command": ".claude/hooks/update-search-year.sh",
-            "timeout": 0.1  // 100ms (timeout is in seconds)
+            "timeout": 0.1 // 100ms (timeout is in seconds)
           }
         ]
       }
@@ -83,7 +115,7 @@ Updated: "fastapi docs 2024-2025"
           {
             "type": "command",
             "command": ".claude/hooks/lint-on-save.sh",
-            "timeout": 0.5  // 500ms (timeout is in seconds)
+            "timeout": 0.5 // 500ms (timeout is in seconds)
           }
         ]
       }
@@ -95,12 +127,14 @@ Updated: "fastapi docs 2024-2025"
 ### Hook Scripts
 
 #### Lint-on-Save (`lint-on-save.sh`)
+
 - Automatically detects project root using `justfile` location
 - Routes to appropriate module: backend, admin, mobile, scripts
 - Uses existing `just lint check <module> --files <file>` commands
 - Shows concise output (first 3 lines of issues only)
 
 #### Search Year Update (`update-search-year.sh`)
+
 - Processes JSON from Claude Code WebSearch tool
 - Smart year detection (avoids version numbers, paths)
 - Escapes: `@pinned` or `year:exact` queries are left unchanged
@@ -109,11 +143,14 @@ Updated: "fastapi docs 2024-2025"
 ## Troubleshooting
 
 ### Hooks Not Running
+
 1. **Check Claude Code version**: Hooks require Claude Code 1.0.54+
 2. **Verify working directory**: Must be in SpaceWalker project root
-3. **Check `/doctor`**: Run `/doctor` in Claude Code to validate hook configuration
+3. **Check `/doctor`**: Run `/doctor` in Claude Code to validate hook
+   configuration
 
 ### Hook Errors
+
 ```bash
 # Test hooks manually
 echo '{"tool_name":"Edit","tool_input":{"file_path":"'$(pwd)'/test.py"}}' | .claude/hooks/lint-on-save.sh
@@ -122,7 +159,9 @@ echo '{"tool_name":"WebSearch","tool_input":{"query":"test docs 2024"}}' | .clau
 ```
 
 ### Disable Hooks Temporarily
+
 Create `.claude/settings.local.json`:
+
 ```json
 {
   "hooks": {}
@@ -132,16 +171,27 @@ Create `.claude/settings.local.json`:
 ## Advanced Configuration
 
 ### Adding Custom Hooks
+
 1. Create script in `.claude/hooks/`
 2. Make executable: `chmod +x .claude/hooks/your-hook.sh`
 3. Add to `.claude/settings.json` hooks configuration
 4. Test manually before committing
 
 ### Hook Development
+
 - Hooks receive JSON via stdin from Claude Code
 - Must exit with code 0 for success, non-zero to block operation
 - Use `jq` to parse JSON input
 - Output to stderr for user feedback, stdout for data flow
+
+## Verification
+
+- Run `ls .claude/hooks/` to confirm `lint-on-save.sh` and
+  `update-search-year.sh` are present.
+- Trigger the lint hook by editing a Python file and confirm the warning format
+  matches the example output.
+- Run a web search in Claude Code containing an outdated year and verify the
+  hook updates the query automatically.
 
 ## Performance Guidelines
 
@@ -154,12 +204,14 @@ Create `.claude/settings.local.json`:
 ## Integration with Existing Workflow
 
 ### Works With
+
 - ✅ All existing `just lint` commands
 - ✅ All module-specific linting (backend/admin/mobile)
 - ✅ Global and project-specific Claude settings
 - ✅ Justfile-first workflow patterns
 
 ### Respects
+
 - ✅ File type restrictions (.py, .ts, .tsx, .js, .jsx)
 - ✅ Module boundaries (backend vs admin vs mobile)
 - ✅ Performance constraints (timeouts in seconds, use 0.1 for 100ms)
@@ -175,4 +227,6 @@ Create `.claude/settings.local.json`:
 
 ---
 
-**Questions?** See [Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks-guide) or ask in #engineering Slack.
+**Questions?** See
+[Claude Code Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks-guide)
+or ask in #engineering Slack.

--- a/docs/development/github-app-integration.md
+++ b/docs/development/github-app-integration.md
@@ -1,6 +1,29 @@
+---
+purpose:
+  "Enable repositories to authenticate via GitHub App for read-only access to
+  llm-cli-tools-core."
+audience: "DevOps engineers, maintainers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # GitHub App Integration Guide
 
-This guide covers how to provide read-only access to `llm-cli-tools-core` from other repositories using a GitHub App. The initial consumers are the `mimir` and `spacewalker` repositories, but the same setup applies to future repos.
+This guide covers how to provide read-only access to `llm-cli-tools-core` from
+other repositories using a GitHub App. The initial consumers are the `mimir` and
+`spacewalker` repositories, but the same setup applies to future repos.
+
+## When to Use This
+
+- Onboard a new repository that needs read access to llm-cli-tools-core or other
+  shared libraries.
+- Rotate credentials or audit GitHub App configuration for compliance.
+
+## Prerequisites
+
+- Organization owner rights (or delegated permission) to manage GitHub Apps.
+- Access to configure organization-level secrets and variables.
 
 ## 1. Register the GitHub App
 
@@ -8,15 +31,19 @@ This guide covers how to provide read-only access to `llm-cli-tools-core` from o
 2. Click **New GitHub App** and configure:
    - **Owner**: the same organization that owns `llm-cli-tools-core`.
    - **Repository access**: `Only on selected repositories`.
-   - **Permissions**: `Metadata: Read` (implicit) and `Contents: Read`. Avoid granting write scopes unless a consumer requires writes later.
+   - **Permissions**: `Metadata: Read` (implicit) and `Contents: Read`. Avoid
+     granting write scopes unless a consumer requires writes later.
    - Skip webhooks unless we add event-driven behavior later.
 3. Save the app registration.
 
 ## 2. Generate Credentials Once
 
-1. From the app settings page, generate a private key (`Generate a private key`).
-2. Store the downloaded PEM file securely; we will copy its full contents (including the `BEGIN/END` lines) into an organization secret.
-3. Note the **App ID** and **Slug** shown on the same settings page. We use the App ID in workflows; the slug becomes the bot account name.
+1. From the app settings page, generate a private key
+   (`Generate a private key`).
+2. Store the downloaded PEM file securely; we will copy its full contents
+   (including the `BEGIN/END` lines) into an organization secret.
+3. Note the **App ID** and **Slug** shown on the same settings page. We use the
+   App ID in workflows; the slug becomes the bot account name.
 
 ## 3. Store Shared Secrets at the Org Level
 
@@ -25,7 +52,9 @@ Create org-wide values so every consumer repo can reuse the same credentials:
 - **Organization secret** `APP_PRIVATE_KEY`: the full PEM contents from step 2.
 - **Organization variable** `APP_ID`: the numeric App ID.
 
-Restrict access to the repositories that should be able to read `llm-cli-tools-core` (currently `llm-cli-tools-core`, `mimir`, and `spacewalker`). Future repos can be opted in without changing existing secrets.
+Restrict access to the repositories that should be able to read
+`llm-cli-tools-core` (currently `llm-cli-tools-core`, `mimir`, and
+`spacewalker`). Future repos can be opted in without changing existing secrets.
 
 ## 4. Install the App Where Needed
 
@@ -42,7 +71,8 @@ The installation scopes the read token to the selected repositories only.
 
 ## 5. Use the App Token in GitHub Actions
 
-In each consumer repo (`mimir`, `spacewalker`, etc.), update workflows that need to clone or query this repo.
+In each consumer repo (`mimir`, `spacewalker`, etc.), update workflows that need
+to clone or query this repo.
 
 ```yaml
 jobs:
@@ -63,12 +93,23 @@ jobs:
           path: llm-cli-tools-core
 ```
 
-Replace `org-name` with the actual organization handle. The generated installation token expires after one hour, so create it inside each job that needs access.
+Replace `org-name` with the actual organization handle. The generated
+installation token expires after one hour, so create it inside each job that
+needs access.
 
 ### Tips
 
-- The same token can authenticate `gh` CLI, REST API, or GraphQL calls by setting `GH_TOKEN` or the `Authorization: Bearer` header.
-- If a workflow already has a job-wide `defaults.run.working-directory`, ensure the checkout path does not collide with existing directories.
+- The same token can authenticate `gh` CLI, REST API, or GraphQL calls by
+  setting `GH_TOKEN` or the `Authorization: Bearer` header.
+- If a workflow already has a job-wide `defaults.run.working-directory`, ensure
+  the checkout path does not collide with existing directories.
+
+## Verification
+
+- Run the provided workflow snippet in a dry-run branch and confirm checkout
+  succeeds using the GitHub App token.
+- Validate that organization secrets (`APP_ID`, `APP_PRIVATE_KEY`) are scoped to
+  the appropriate repositories.
 
 ## 6. Onboarding Future Repos
 
@@ -90,8 +131,11 @@ Keep the App ID unchanged; only the private key rotates.
 
 ## 8. Troubleshooting
 
-- **403 Forbidden**: the app is not installed on the target repo or lacks `Contents: Read` permission.
-- **404 Not Found**: the token is valid but the repository is not in the installation scope.
-- **Expired token**: re-run the step; tokens last 60 minutes and cannot be refreshed.
+- **403 Forbidden**: the app is not installed on the target repo or lacks
+  `Contents: Read` permission.
+- **404 Not Found**: the token is valid but the repository is not in the
+  installation scope.
+- **Expired token**: re-run the step; tokens last 60 minutes and cannot be
+  refreshed.
 
 Ask an org admin to review audit logs if unexpected behavior persists.

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,3 +91,33 @@ follow the templates in `.docs-templates/`.
 ## Pending Gaps
 
 - Add onboarding walkthrough once the shared telemetry workflow is finalized.
+
+## Frontmatter fields
+
+| Field     | Purpose                                      | Notes                          |
+|-----------|----------------------------------------------|--------------------------------|
+| `purpose` | One-line statement of why the doc exists      | Displayed at top of documents  |
+| `audience`| Primary readers (roles/teams)                 | Guides tone and depth          |
+| `owner`   | Accountable individual or team                | Update when stewardship shifts |
+| `review`  | Planned review cadence (e.g., Quarterly)      | Drives doc hygiene reminders   |
+| `status`  | Active / Draft / Deprecated lifecycle         | Signals whether doc is current |
+
+## Docs validation configuration
+
+The docs tooling reads environment variables (set via the shell or a `.env` file) to override defaults:
+
+- `DOCS_CSPELL_FILES` – files/globs passed to cspell
+- `DOCS_LYCHEE_FILES` – files/globs passed to lychee
+- `DOCS_LYCHEE_ARGS` – additional lychee arguments
+- `DOCS_CSPELL_CONFIG` – alternate cspell config path
+- `DOCS_LYCHEE_CONFIG` – alternate lychee config path
+- `DOCS_LYCHEE_VERSION` – required lychee version (default `0.13.0`)
+
+Use these overrides sparingly; the CI workflow runs with the defaults defined in `scripts/docs_phase2.sh`.
+
+## Release notes
+
+- Release automation bumps versions when commits merged to `main` use a `feat:`
+  or `fix:` prefix.
+- Include documentation-impacting changes in those commits when they should
+  appear in the generated changelog.

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,30 +94,26 @@ follow the templates in `.docs-templates/`.
 
 ## Frontmatter fields
 
-| Field     | Purpose                                      | Notes                          |
-|-----------|----------------------------------------------|--------------------------------|
-| `purpose` | One-line statement of why the doc exists      | Displayed at top of documents  |
-| `audience`| Primary readers (roles/teams)                 | Guides tone and depth          |
-| `owner`   | Accountable individual or team                | Update when stewardship shifts |
-| `review`  | Planned review cadence (e.g., Quarterly)      | Drives doc hygiene reminders   |
-| `status`  | Active / Draft / Deprecated lifecycle         | Signals whether doc is current |
+- `purpose`: One-line statement of why the doc exists.
+- `audience`: Primary readers (roles/teams) guiding tone and depth.
+- `owner`: Accountable individual or team; update when stewardship shifts.
+- `review`: Planned cadence (e.g., Quarterly) used for doc hygiene reminders.
+- `status`: Lifecycle state (Active / Draft / Deprecated) signalling freshness.
 
 ## Docs validation configuration
 
-The docs tooling reads environment variables (set via the shell or a `.env` file) to override defaults:
+The docs tooling reads environment variables (shell or `.env`) to override defaults:
 
 - `DOCS_CSPELL_FILES` – files/globs passed to cspell
 - `DOCS_LYCHEE_FILES` – files/globs passed to lychee
-- `DOCS_LYCHEE_ARGS` – additional lychee arguments
+- `DOCS_LYCHEE_ARGS` – extra flags for lychee
 - `DOCS_CSPELL_CONFIG` – alternate cspell config path
 - `DOCS_LYCHEE_CONFIG` – alternate lychee config path
 - `DOCS_LYCHEE_VERSION` – required lychee version (default `0.13.0`)
 
-Use these overrides sparingly; the CI workflow runs with the defaults defined in `scripts/docs_phase2.sh`.
+Use overrides sparingly; CI runs with the defaults defined in `scripts/docs_phase2.sh`.
 
 ## Release notes
 
-- Release automation bumps versions when commits merged to `main` use a `feat:`
-  or `fix:` prefix.
-- Include documentation-impacting changes in those commits when they should
-  appear in the generated changelog.
+- Version bumps occur when commits merged to `main` use `feat:` or `fix:`.
+- Add doc-impacting changes to those commits so the changelog stays accurate.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,93 @@
+---
+purpose:
+  "Provide a single entry point and taxonomy for llm-cli-tools-core
+  documentation."
+audience: "Contributors, maintainers, reviewers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
+# Documentation Index
+
+This index maps the shared documentation taxonomy and highlights the status of
+each asset. Every document should begin with the standard metadata block and
+follow the templates in `.docs-templates/`.
+
+## Doc Types
+
+### Overview & Quickstart
+
+- **Primary Docs:** [README.md](../README.md), [CONTEXT.md](../CONTEXT.md)
+- **Status:** Active
+- **Notes:** Product summary, install paths, current capabilities.
+
+### Contributor Guide
+
+- **Primary Docs:** [CLAUDE.md](../CLAUDE.md)
+- **Status:** Active
+- **Notes:** Mandatory workflow, tooling, and review standards.
+
+### Architecture & Context
+
+- **Primary Docs:** [CONTEXT.md](../CONTEXT.md),
+  [docs/development/claude-context-management.md](development/claude-context-management.md)
+- **Status:** Active
+- **Notes:** Problem framing, context hierarchy, inheritance model.
+
+### How-to / Runbooks
+
+- **Primary Docs:**
+  [docs/development/claude-hooks-setup.md](development/claude-hooks-setup.md),
+  [docs/development/github-app-integration.md](development/github-app-integration.md)
+- **Status:** Active
+- **Notes:** Step-by-step procedures with verification guidance.
+
+### CLI / Command Reference
+
+- **Primary Docs:** [docs/development/claude-commands.md](development/claude-commands.md)
+- **Status:** Active
+- **Notes:** Slash-command catalogue and usage examples.
+
+### Policies & Standards
+
+- **Primary Docs:**
+  [docs/claude-components/deployment-gt-workflow.md](claude-components/deployment-gt-workflow.md)
+- **Status:** Active
+- **Notes:** Non-negotiable deployment rules and guardrails.
+
+### Workflow Runbooks
+
+- **Primary Docs:**
+  [docs/workflows/claude-review-workflows.md](workflows/claude-review-workflows.md)
+- **Status:** Active
+- **Notes:** GitHub and local automation guidance.
+
+### Deprecated Assets
+
+- **Primary Docs:**
+  [docs/workflows/claude-multi-focus-review.md](workflows/claude-multi-focus-review.md)
+- **Status:** Deprecated
+- **Notes:** Redirects to `claude-review-workflows.md`.
+
+## Templates & Conventions
+
+- Template sources: `.docs-templates/` (overview, contributor, architecture,
+  how-to, CLI, policy).
+- Metadata block keys (all required): `purpose`, `audience`, `owner`, `review`,
+  `status`.
+- Each document must include **When to Use This**, **Prerequisites**, and
+  **Verification** sections when applicable.
+
+## Maintenance Checklist
+
+- Run `just docs check` (markdownlint + cspell + lychee) before merging
+  documentation changes.
+- Ensure Node.js 18+ and a Rust toolchain (lychee) are available locally to run
+  `scripts/docs_phase2.sh`.
+- Update the `owner` and `review` fields when ownership changes.
+- Mark deprecated docs with `status: Deprecated` and link to the replacement.
+
+## Pending Gaps
+
+- Add onboarding walkthrough once the shared telemetry workflow is finalized.

--- a/docs/workflows/claude-multi-focus-review.md
+++ b/docs/workflows/claude-multi-focus-review.md
@@ -1,18 +1,46 @@
+---
+purpose:
+  "Document the deprecated multi-focus review workflow and point to the
+  replacement."
+audience: "Contributors maintaining historical workflows"
+owner: "Core AI Tools"
+review: "As needed when workflows change"
+status: "Deprecated"
+---
+
 # Claude Multi-Focus Review (Deprecated)
 
 **This workflow has been simplified!**
 
-Please see [Claude Review Workflows](./claude-review-workflows.md) for the new streamlined approach.
+Please see [Claude Review Workflows](./claude-review-workflows.md) for the new
+streamlined approach.
+
+## When to Use This
+
+- Only when auditing historical runs or understanding legacy automation
+  decisions.
+
+## Prerequisites
+
+- None. Use the replacement workflow for active reviews.
 
 ## What Changed
 
-We consolidated from multiple separate workflows to a single unified workflow with 2 review sections:
+We consolidated from multiple separate workflows to a single unified workflow
+with 2 review sections:
+
 - **Technical Review**: Architecture, security, testing, functionality
 - **Standards Review**: Documentation, patterns, conventions, justfile
 
 This simplification:
+
 - Provides all feedback in one comprehensive comment
-- Fixes the 40k character repository issue  
+- Fixes the 40k character repository issue
 - Uses the proven `custom_instructions` approach that actually works
 - Triggered only by `@claude` comments (not automatic on every PR)
 - Easier to maintain and debug
+
+## Verification
+
+- Confirm `.github/workflows/claude.yml` has replaced any references to the
+  multi-focus workflow before removing this document.

--- a/docs/workflows/claude-review-workflows.md
+++ b/docs/workflows/claude-review-workflows.md
@@ -1,25 +1,49 @@
+---
+purpose: "Runbook for triggering and interpreting Claude-powered PR reviews."
+audience: "Developers, reviewers, release managers"
+owner: "Core AI Tools"
+review: "Quarterly (Jan, Apr, Jul, Oct)"
+status: "Active"
+---
+
 # Claude Review Workflows
 
-SpaceWalker uses Claude for automated code reviews on PRs via GitHub comments (official action) and optional local tools.
+SpaceWalker uses Claude for automated code reviews on PRs via GitHub comments
+(official action) and optional local tools.
+
+## When to Use This
+
+- Request AI-assisted code reviews directly in GitHub pull requests.
+- Compare local analysis versus hosted review outputs before merging.
+
+## Prerequisites
+
+- Repository secret `ANTHROPIC_API_KEY` populated.
+- Optional model override variables configured when deviating from defaults.
 
 What’s new
+
 - Official action: anthropics/claude-code-action@v1
 - Targeted categories: docs, justfile, correctness, overengineering
 - Multi-select: “review docs, justfile” or “review all”
-- Sticky comments: single sticky per category when run individually; separate category metrics when multiple run together
+- Sticky comments: single sticky per category when run individually; separate
+  category metrics when multiple run together
 - Metrics: model, token counts, and estimated cost per run
 
 Secrets, variables, and defaults
-- Required secret: ANTHROPIC_API_KEY
-– Optional repo variables (models):
-  - CLAUDE_MODEL_DOCS, CLAUDE_MODEL_JUSTFILE, CLAUDE_MODEL_CORRECTNESS, CLAUDE_MODEL_OVERENGINEERING, CLAUDE_MODEL_DEFAULT
-  - Defaults: all categories → claude-4-1-sonnet-20250805 (set CLAUDE_MODEL_HAIKU or category-specific variables to override)
+
+- Required secret: ANTHROPIC_API_KEY – Optional repo variables (models):
+  - CLAUDE_MODEL_DOCS, CLAUDE_MODEL_JUSTFILE, CLAUDE_MODEL_CORRECTNESS,
+    CLAUDE_MODEL_OVERENGINEERING, CLAUDE_MODEL_DEFAULT
+  - Defaults: all categories → claude-4-1-sonnet-20250805 (set
+    CLAUDE_MODEL_HAIKU or category-specific variables to override)
 - Optional costs:
   - Preferred: CLAUDE_COSTS_JSON (JSON map of model → { in, out })
   - Fallback file: .github/claude-costs.json (checked in with real rates)
   - Global fallback: CLAUDE_INPUT_COST_PER_MTOK, CLAUDE_OUTPUT_COST_PER_MTOK
 
 GitHub-triggered usage
+
 - Comment on the PR (top-level or inline):
   - “@claude review docs” or “/claude review docs”
   - “@claude review justfile” or “/claude review justfile”
@@ -28,17 +52,31 @@ GitHub-triggered usage
   - “@claude review all” or “/claude review all” (runs all four)
 
 Review outputs
+
 - Category review comment(s) with findings and next actions
-- Sticky metrics comment per category: model, input/output tokens, estimated cost, run link
+- Sticky metrics comment per category: model, input/output tokens, estimated
+  cost, run link
 
 Implementation
+
 - Workflow: .github/workflows/claude.yml
 - Official action: v1
-- Category prompts enforce CLAUDE.md standards, Justfile-first patterns, and SpaceWalker rules
-- Multi-category runs avoid single-comment collisions by posting category-specific outputs and metrics
+- Category prompts enforce CLAUDE.md standards, Justfile-first patterns, and
+  SpaceWalker rules
+- Multi-category runs avoid single-comment collisions by posting
+  category-specific outputs and metrics
+
+## Verification
+
+- Trigger `/claude review docs` on a sample PR and confirm the workflow posts
+  category-specific comments and metrics.
+- Review the sticky metrics comment to ensure token and cost values populate as
+  expected.
 
 Local PR analysis (optional)
+
 - For quick, local insights during development:
+
 ```bash
 # Complete PR review with AI analysis (summary)
 just git-info pr-review-issues 290 --analysis=summary
@@ -58,23 +96,25 @@ just gh-pr 290 --repo=other/repo
 
 ### Key Differences from GitHub Reviews
 
-| Feature | GitHub (`@claude`) | Local (`just gh-pr`) |
-|---------|-------------------|-------------------|
-| Trigger | PR comment | Command line |
-| Speed | ~2-5 minutes | Immediate |
-| Results | Posted to PR | Terminal output |
-| Model | Claude Opus 4 | Claude Haiku (configurable) |
-| Scope | Full PR diff | Targeted analysis |
+| Feature | GitHub (`@claude`) | Local (`just gh-pr`)        |
+| ------- | ------------------ | --------------------------- |
+| Trigger | PR comment         | Command line                |
+| Speed   | ~2-5 minutes       | Immediate                   |
+| Results | Posted to PR       | Terminal output             |
+| Model   | Claude Opus 4      | Claude Haiku (configurable) |
+| Scope   | Full PR diff       | Targeted analysis           |
 
 ### When to Use Each
 
 **Use GitHub Reviews (`@claude`) when:**
+
 - You want review results documented in the PR
 - Multiple team members need to see the analysis
 - You're doing a final review before merge
 - You need deep, comprehensive analysis
 
 **Use Local Analysis (`just gh-pr`) when:**
+
 - You need quick insights during development
 - You're iterating on PR feedback
 - You want to check specific aspects (risk, test status)
@@ -87,13 +127,18 @@ just gh-pr 290 --repo=other/repo
 just git-info pr-review-issues <pr_number>
 
 # Individual analyses
-just git-info pr-review-issues <pr_number> --analysis=summary        # Comprehensive AI review
-just git-info pr-review-issues <pr_number> --analysis=comments       # Comment thread analysis
-just git-info pr-review-issues <pr_number> --analysis=risk           # Risk assessment
-just git-info pr-review-issues <pr_number> --analysis=test-freshness # Test timing analysis
+just git-info pr-review-issues <pr_number> --analysis=summary \
+  # Comprehensive AI review
+just git-info pr-review-issues <pr_number> --analysis=comments \
+  # Comment thread analysis
+just git-info pr-review-issues <pr_number> --analysis=risk \
+  # Risk assessment
+just git-info pr-review-issues <pr_number> --analysis=test-freshness \
+  # Test timing analysis
 
 # Actionable, time-aware list (new)
-just git-info pr-review-issues <pr_number> --analysis=actionable --since-last-push
+just git-info pr-review-issues <pr_number> --analysis=actionable \
+  --since-last-push
 
 # Data commands
 just gh-pr fetch <pr_number>            # Raw PR data (JSON)
@@ -102,10 +147,13 @@ just gh-pr test-status <pr_number>      # CI/CD check status
 ```
 
 Troubleshooting
-- Not triggering: ensure @claude appears in a PR comment (not issues), and you have write access
+
+- Not triggering: ensure @claude appears in a PR comment (not issues), and you
+  have write access
 - No metrics cost: set CLAUDE_COSTS_JSON or update .github/claude-costs.json
 - Wrong model: set the category model variables above
 
 Related docs
+
 - Codex Reviewer: see ./codex-review-workflows.md
 - PR Analysis Guide: ./pr-analysis-guide.md

--- a/justfile
+++ b/justfile
@@ -2,6 +2,10 @@
 set dotenv-load
 set shell := ["bash", "-c"]
 
+docs_directory := "docs"
+docs_templates := ".docs-templates"
+docs_root := justfile_directory()
+
 # Use UV for all Python operations
 python := "uv run python"
 pytest := "uv run pytest"
@@ -21,6 +25,7 @@ help:
     @echo "  just test [target]         - Run tests (all/unit/integration)"
     @echo "  just lint [action]         - Lint code (check/format)"
     @echo "  just ci                    - Run full CI pipeline"
+    @echo "  just docs check            - Validate docs (lint + spell + links)"
     @echo ""
     @echo "Installation:"
     @echo "  just install-local         - Install package locally for testing"
@@ -63,6 +68,23 @@ ci:
     @just lint check
     @just test all
     @echo "✅ CI pipeline passed"
+
+# Validate documentation (markdownlint + cspell + lychee)
+docs action='help' *args='':
+    @if [ "{{action}}" = "help" ]; then \
+        echo "Usage: just docs check"; \
+        exit 0; \
+    elif [ "{{action}}" = "check" ]; then \
+        set -euo pipefail; \
+        FILES="{{docs_root}}/README.md {{docs_root}}/CLAUDE.md {{docs_root}}/CONTEXT.md"; \
+        TEMPLATE_LIST=$(find "{{docs_root}}/{{docs_templates}}" -name '*.md' -print 2>/dev/null | tr '\n' ' '); \
+        DOC_LIST=$(find "{{docs_root}}/{{docs_directory}}" -name '*.md' -print 2>/dev/null | tr '\n' ' '); \
+        npx --yes markdownlint-cli2@0.12.1 $FILES $DOC_LIST $TEMPLATE_LIST; \
+        ./scripts/docs_phase2.sh; \
+    else \
+        echo "Unknown docs action: {{action}}"; \
+        exit 1; \
+    fi
 
 # Install package locally for testing
 install-local:

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,11 @@
+cache = true
+max_concurrency = 4
+retry_wait_time = 2
+max_redirects = 5
+
+exclude = [
+  "https://github.com/degree-analytics/llm-cli-tools-core/issues",
+]
+
+exclude_dupe = true
+exclude_all_private = true

--- a/scripts/docs_phase2.sh
+++ b/scripts/docs_phase2.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docs validation configuration can be overridden via environment variables
+# (see docs/index.md for the list of supported DOCS_* options).
+
+: "${DOCS_CSPELL_FILES:=README.md CLAUDE.md CONTEXT.md docs/**/*.md .docs-templates/*.md}"
+: "${DOCS_LYCHEE_FILES:=README.md CLAUDE.md CONTEXT.md docs/**/*.md}"
+: "${DOCS_LYCHEE_ARGS:=--max-concurrency 4 --timeout 20 --retry-wait-time 2 --no-progress}"
+: "${DOCS_CSPELL_CONFIG:=cspell.config.yaml}"
+: "${DOCS_LYCHEE_CONFIG:=lychee.toml}"
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "❌ npx not found. Install Node.js 18+ to run spell checking." >&2
+  exit 1
+fi
+
+if [ ! -f "$DOCS_CSPELL_CONFIG" ]; then
+  echo "ℹ️  Generating default cspell config at $DOCS_CSPELL_CONFIG" >&2
+  cat <<'CFG' > "$DOCS_CSPELL_CONFIG"
+version: "0.2"
+language: en
+words:
+  - Mímir
+  - openrouter
+  - pushgateway
+  - Pushgateway
+  - PUSHGATEWAY
+  - overengineering
+  - justfile
+  - automations
+  - dataclass
+  - Groundtruth
+  - Claude
+  - Spacewalker
+  - pytest
+  - pyproject
+  - chadwalters
+  - getenv
+  - commandname
+  - fastapi
+  - Runbook
+  - anthropics
+  - MTOK
+flagWords: []
+ignorePaths:
+  - "**/node_modules/**"
+  - "**/.git/**"
+  - "**/dist/**"
+  - "**/.cache/**"
+CFG
+fi
+
+echo "🧡 Running cspell…"
+npx --yes cspell@7.2.0 lint --config "$DOCS_CSPELL_CONFIG" $DOCS_CSPELL_FILES
+
+echo "🌐 Running lychee…"
+REQUIRED_LYCHEE_VERSION=${DOCS_LYCHEE_VERSION:-0.13.0}
+
+if ! command -v lychee >/dev/null 2>&1; then
+  echo "❌ lychee not found. Install it with: cargo install lychee --version ${REQUIRED_LYCHEE_VERSION}" >&2
+  exit 1
+fi
+
+installed=$(lychee --version | awk '{print $2}')
+if [ "$installed" != "$REQUIRED_LYCHEE_VERSION" ]; then
+  echo "❌ lychee $REQUIRED_LYCHEE_VERSION required (found $installed). Reinstall with: cargo install lychee --version $REQUIRED_LYCHEE_VERSION" >&2
+  exit 1
+fi
+
+if [ -f "$DOCS_LYCHEE_CONFIG" ]; then
+  lychee --config "$DOCS_LYCHEE_CONFIG" $DOCS_LYCHEE_ARGS $DOCS_LYCHEE_FILES
+else
+  lychee $DOCS_LYCHEE_ARGS $DOCS_LYCHEE_FILES
+fi
+
+echo "✅ Phase 2 docs checks complete."

--- a/scripts/docs_phase2.sh
+++ b/scripts/docs_phase2.sh
@@ -55,16 +55,30 @@ echo "🧡 Running cspell…"
 npx --yes cspell@7.2.0 lint --config "$DOCS_CSPELL_CONFIG" $DOCS_CSPELL_FILES
 
 echo "🌐 Running lychee…"
-REQUIRED_LYCHEE_VERSION=${DOCS_LYCHEE_VERSION:-0.13.0}
+MIN_LYCHEE_VERSION=${DOCS_LYCHEE_VERSION:-0.13.0}
+MAX_LYCHEE_VERSION=${DOCS_LYCHEE_MAX_VERSION:-0.14.0}
 
 if ! command -v lychee >/dev/null 2>&1; then
-  echo "❌ lychee not found. Install it with: cargo install lychee --version ${REQUIRED_LYCHEE_VERSION}" >&2
+  echo "❌ lychee not found. Install via: cargo install lychee --version ${MIN_LYCHEE_VERSION}" >&2
   exit 1
 fi
 
 installed=$(lychee --version | awk '{print $2}')
-if [ "$installed" != "$REQUIRED_LYCHEE_VERSION" ]; then
-  echo "❌ lychee $REQUIRED_LYCHEE_VERSION required (found $installed). Reinstall with: cargo install lychee --version $REQUIRED_LYCHEE_VERSION" >&2
+version_ge() {
+  printf '%s
+' "$1" "$2" | sort -V | tail -n1 | grep -qx "$2"
+}
+version_lt() {
+  [ "$1" = "$2" ] && return 1
+  printf '%s
+' "$1" "$2" | sort -V | head -n1 | grep -qx "$1"
+}
+if ! version_ge "$installed" "$MIN_LYCHEE_VERSION"; then
+  echo "❌ lychee >= $MIN_LYCHEE_VERSION required (found $installed). Reinstall with: cargo install lychee --version $MIN_LYCHEE_VERSION" >&2
+  exit 1
+fi
+if ! version_lt "$installed" "$MAX_LYCHEE_VERSION"; then
+  echo "❌ lychee versions >= $MAX_LYCHEE_VERSION are not yet validated (found $installed). Pin to: cargo install lychee --version $MIN_LYCHEE_VERSION" >&2
   exit 1
 fi
 

--- a/scripts/helpers/claude_metrics.py
+++ b/scripts/helpers/claude_metrics.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, Sequence
+
+Number = int | float
+
+
+@dataclass(frozen=True)
+class Metrics:
+    in_tokens: int
+    out_tokens: int
+    model: str
+    est_cost_usd: Decimal | None = None
+
+    def to_output_pairs(self) -> Iterator[tuple[str, str]]:
+        yield "in_tokens", str(self.in_tokens)
+        yield "out_tokens", str(self.out_tokens)
+        if self.model:
+            yield "model", self.model
+        if self.est_cost_usd is not None:
+            yield "est_cost_usd", f"{self.est_cost_usd:.6f}"
+
+
+INPUT_PATHS: Sequence[Sequence[str]] = (
+    ("usage", "inputTokens"),
+    ("usage", "input_tokens"),
+    ("metrics", "input_tokens"),
+    ("result", "usage", "input_tokens"),
+    ("result", "usage", "inputTokens"),
+)
+OUTPUT_PATHS: Sequence[Sequence[str]] = (
+    ("usage", "outputTokens"),
+    ("usage", "output_tokens"),
+    ("metrics", "output_tokens"),
+    ("result", "usage", "output_tokens"),
+    ("result", "usage", "outputTokens"),
+)
+MODEL_PATHS: Sequence[Sequence[str]] = (
+    ("model",),
+    ("meta", "model"),
+    ("result", "model"),
+)
+
+
+class MetricsParseError(ValueError):
+    """Raised when the execution metrics payload is malformed."""
+
+
+def collect_metrics_from_file(
+    execution_path: Path | str,
+    *,
+    costs_json: str | None = None,
+    costs_file: Path | str | None = None,
+    fallback_in_rate: Decimal | Number | str | None = None,
+    fallback_out_rate: Decimal | Number | str | None = None,
+) -> Mapping[str, object]:
+    path = Path(execution_path)
+    records = _load_records(path)
+    in_tokens = _sum_fields(records, INPUT_PATHS)
+    out_tokens = _sum_fields(records, OUTPUT_PATHS)
+    model = _pick_model(records)
+    cost_map = _load_cost_map(costs_json, costs_file)
+    rates = _resolve_rates(model, cost_map, fallback_in_rate, fallback_out_rate)
+    est_cost = _estimate_cost(in_tokens, out_tokens, rates)
+    if est_cost is not None:
+        est_cost = est_cost.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+    metrics = Metrics(in_tokens=in_tokens, out_tokens=out_tokens, model=model, est_cost_usd=est_cost)
+    output: dict[str, object] = {
+        "in_tokens": metrics.in_tokens,
+        "out_tokens": metrics.out_tokens,
+    }
+    if metrics.model:
+        output["model"] = metrics.model
+    if metrics.est_cost_usd is not None:
+        output["est_cost_usd"] = metrics.est_cost_usd
+    return output
+
+
+def _load_records(path: Path) -> list[dict]:
+    try:
+        raw = path.read_text().strip()
+    except FileNotFoundError as exc:
+        raise MetricsParseError(f"Execution file not found: {path}") from exc
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        records: list[dict] = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:  # pragma: no cover
+                raise MetricsParseError(f"Invalid JSON line in {path!s}") from exc
+        if not records:
+            raise MetricsParseError(f"Execution file {path!s} does not contain valid JSON")
+        return records
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
+    if isinstance(parsed, dict):
+        return [parsed]
+    raise MetricsParseError(f"Unexpected payload type in {path!s}: {type(parsed).__name__}")
+
+
+def _sum_fields(records: Iterable[Mapping[str, object]], paths: Sequence[Sequence[str]]) -> int:
+    total = 0
+    for record in records:
+        for path in paths:
+            value = _dig(record, path)
+            if isinstance(value, (int, float)):
+                total += int(value)
+                break
+    return total
+
+
+def _pick_model(records: Iterable[Mapping[str, object]]) -> str:
+    model_candidates: list[str] = []
+    for record in records:
+        for path in MODEL_PATHS:
+            value = _dig(record, path)
+            if isinstance(value, str):
+                model_candidates.append(value)
+    return model_candidates[-1] if model_candidates else "unknown"
+
+
+def _dig(record: Mapping[str, object], path: Sequence[str]) -> object | None:
+    current: object | None = record
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _load_cost_map(costs_json: str | None, costs_file: Path | str | None) -> dict[str, dict[str, Number]] | None:
+    if costs_json:
+        try:
+            return json.loads(costs_json)
+        except json.JSONDecodeError as exc:
+            raise MetricsParseError("Invalid COSTS_JSON payload") from exc
+    if costs_file:
+        file_path = Path(costs_file)
+        if file_path.is_file():
+            try:
+                with file_path.open("r", encoding="utf-8") as fh:
+                    return json.load(fh)
+            except json.JSONDecodeError as exc:  # pragma: no cover
+                raise MetricsParseError(f"Invalid JSON in costs file: {costs_file}") from exc
+    return None
+
+
+def _resolve_rates(
+    model: str,
+    cost_map: Mapping[str, Mapping[str, Number]] | None,
+    fallback_in_rate: Decimal | Number | str | None,
+    fallback_out_rate: Decimal | Number | str | None,
+) -> tuple[Decimal | None, Decimal | None]:
+    if cost_map and model in cost_map:
+        entry = cost_map[model]
+        return _coerce_decimal(entry.get("in")), _coerce_decimal(entry.get("out"))
+    return _coerce_decimal(fallback_in_rate), _coerce_decimal(fallback_out_rate)
+
+
+def _coerce_decimal(value: Decimal | Number | str | None) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except Exception as exc:  # pragma: no cover
+        raise MetricsParseError(f"Unable to coerce value '{value}' to Decimal") from exc
+
+
+def _estimate_cost(
+    in_tokens: int,
+    out_tokens: int,
+    rates: tuple[Decimal | None, Decimal | None],
+) -> Decimal | None:
+    in_rate, out_rate = rates
+    if in_rate is None or out_rate is None:
+        return None
+    million = Decimal("1000000")
+    cost_in = (Decimal(in_tokens) / million) * in_rate
+    cost_out = (Decimal(out_tokens) / million) * out_rate
+    return cost_in + cost_out
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggregate Claude execution metrics")
+    parser.add_argument("execution_file", type=Path)
+    parser.add_argument("--costs-json", dest="costs_json")
+    parser.add_argument("--costs-file", dest="costs_file")
+    parser.add_argument("--fallback-in-rate", dest="fallback_in_rate")
+    parser.add_argument("--fallback-out-rate", dest="fallback_out_rate")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    metrics = collect_metrics_from_file(
+        args.execution_file,
+        costs_json=args.costs_json,
+        costs_file=args.costs_file,
+        fallback_in_rate=args.fallback_in_rate,
+        fallback_out_rate=args.fallback_out_rate,
+    )
+    for key, value in metrics.items():
+        print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add shared `scripts/docs_phase2.sh` to run cspell + lychee after markdownlint
- wire the script into `just docs check` and docs-quality workflow so spell/link checks run by default
- add shared `cspell.config.yaml`/`lychee.toml` and update docs guidance for the new requirements

## Testing
- just docs check